### PR TITLE
Added assembla to git free hosts

### DIFF
--- a/en/preface.txt
+++ b/en/preface.txt
@@ -48,6 +48,7 @@ If I've left you out by mistake, please tell me or just send me a patch!
  - http://repo.or.cz/[http://repo.or.cz/] hosts free projects. The first Git hosting site. Founded and maintained by one of the earliest Git developers.
  - http://gitorious.org/[http://gitorious.org/] is another Git hosting site aimed at open-source projects.
  - http://github.com/[http://github.com/] hosts open-source projects for free, and private projects for a fee.
+ - http://www.assembla.com/[http://www.assembla.com/] hosts up to 2GB for free for open or private projects.
 
 Many thanks to each of these sites for hosting this guide.
 


### PR DESCRIPTION
Assembla also offers free git hosting and also allows private projects up to 2GB
