### PR TITLE
Fix typos.

### DIFF
--- a/en/basic.txt
+++ b/en/basic.txt
@@ -1,7 +1,7 @@
 == Basic Tricks ==
 
 Rather than diving into a sea of Git commands, use these elementary examples to
-get your feet wet. Despite their simplicity, each of them are useful.
+get your feet wet. Despite their simplicity, each of them is useful.
 Indeed, in my first months with Git I never ventured beyond the material in this chapter.
 
 === Saving State ===
@@ -71,7 +71,7 @@ Other times you want to hop to an old state briefly. In this case, type:
 
  $ git checkout 82f5
 
-This takes you back in time, while preserving newer commits. However, like time travel in a science-fiction movie, if you now edit and commit, you will be in an alternate reality, because your actions are different to what they were the first time around.
+This takes you back in time, while preserving newer commits. However, like time travel in a science-fiction movie, if you now edit and commit, you will be in an alternate reality, because your actions are different from what they were the first time around.
 
 This alternate reality is called a 'branch', and <<branch,we'll have more to say about this later>>. For now, just remember that
 

--- a/en/branch.txt
+++ b/en/branch.txt
@@ -16,7 +16,7 @@ With this magic word, the files in your directory suddenly shapeshift from one v
 
 === The Boss Key ===
 
-Ever played one of those games where at the push of a button (``the boss key''), the screen would instantly display a spreadsheet or something? So if the boss walked in the office while you were playing the game you could quickly hide it away?
+Ever played one of those games where at the push of a button (``the boss key''), the screen would instantly display a spreadsheet or something? So if the boss walked into the office while you were playing the game you could quickly hide it away?
 
 In some directory:
 

--- a/en/clone.txt
+++ b/en/clone.txt
@@ -38,7 +38,7 @@ Start the Git daemon if necessary:
 
  $ git daemon --detach  # it may already be running
 
-For Git hosting services, follow the instructions to setup the initially
+For Git hosting services, follow the instructions to set up the initially
 empty Git repository. Typically one fills in a form on a webpage.
 
 'Push' your project to the central server with:

--- a/en/drawbacks.txt
+++ b/en/drawbacks.txt
@@ -80,7 +80,7 @@ The current implementation of Git, rather than its design, is to blame for this 
 
 === Initial Commit ===
 
-A stereotypical computer scientist counts from 0, rather than 1. Unfortunately, with respect to commits, git does not adhere to this convention. Many commands are unfriendly before the initial commit. Additionally, some corner cases must be handled specially, such as rebasing a branch with a different initial commit.
+A stereotypical computer scientist counts from 0, rather than 1. Unfortunately, with respect to commits, Git does not adhere to this convention. Many commands are unfriendly before the initial commit. Additionally, some corner cases must be handled specially, such as rebasing a branch with a different initial commit.
 
 Git would benefit from defining the zero commit: as soon as a repository is constructed, HEAD would be set to the string consisting of 20 zero bytes. This special commit represents an empty tree, with no parent, at some time predating all Git repositories.
 

--- a/en/history.txt
+++ b/en/history.txt
@@ -4,7 +4,7 @@ A consequence of Git's distributed nature is that history can be edited
 easily. But if you tamper with the past, take care: only rewrite that part of
 history which you alone possess. Just as nations forever argue over who
 committed what atrocity, if someone else has a clone whose version of history
-differs to yours, you will have trouble reconciling when your trees interact.
+differs from yours, you will have trouble reconciling when your trees interact.
 
 Some developers strongly feel history should be immutable, warts and all.
 Others feel trees should be made presentable before they are unleashed in

--- a/en/multiplayer.txt
+++ b/en/multiplayer.txt
@@ -41,7 +41,7 @@ Now you can publish your latest edits via SSH from any clone:
 
  $ git push web.server:/path/to/proj.git master
 
-and anybody can get your project with:
+and anyone can get your project with:
 
  $ git clone http://web.server/proj.git
 

--- a/en/preface.txt
+++ b/en/preface.txt
@@ -4,7 +4,7 @@ August 2007
 
 == Preface ==
 
-http://git-scm.com/[Git] is a version control Swiss army knife. A reliable versatile multipurpose revision control tool whose extraordinary flexibility makes it tricky to learn, let alone master.
+http://git-scm.com/[Git] is a version control Swiss army knife. A reliable, versatile, multipurpose revision control tool whose extraordinary flexibility makes it tricky to learn, let alone master.
 
 As Arthur C. Clarke observed, any sufficiently advanced technology is indistinguishable from magic. This is a great way to approach Git: newbies can ignore its inner workings and view Git as a gizmo that can amaze friends and infuriate enemies with its wondrous abilities.
 

--- a/en/translate.txt
+++ b/en/translate.txt
@@ -8,7 +8,7 @@ Clone the source, then create a directory corresponding to the target
 language's IETF tag: see
 http://www.w3.org/International/articles/language-tags/Overview.en.php[the W3C
 article on internationalization]. For example, English is "en" and Japanese is
-"ja". In the new directory, and translate the +txt+ files from the "en"
+"ja". In the new directory, translate the +txt+ files from the "en"
 subdirectory.
 
 For instance, to translate the guide into http://en.wikipedia.org/wiki/Klingon_language[Klingon], you might type:


### PR DESCRIPTION
Very minor typos, in → into, setup -> set up, consistent capitalization of Git.